### PR TITLE
Update to expose `factoryFor` method.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.0.0",
+    "ember-cli-qunit": "^3.1.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-debug-handlers-polyfill": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
@@ -46,10 +47,12 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-version-checker": "^1.2.0"
+    "ember-cli-version-checker": "^1.2.0",
+    "ember-factory-for-polyfill": "^1.1.0"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-factory-for-polyfill"
   },
   "main": "index.js",
   "bugs": {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -36,7 +36,6 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
-    ENV.EmberENV.RAISE_ON_DEPRECATION = true;
   }
 
   if (environment === 'production') {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,6 +1,32 @@
+import Ember from 'ember';
+import QUnit from 'qunit';
 import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
 
 setResolver(resolver);
+
+let deprecations;
+Ember.Debug.registerDeprecationHandler((message, options, next) => {
+  deprecations.push(message);
+  next(message, options);
+});
+
+QUnit.testStart(function() {
+  deprecations = [];
+});
+
+QUnit.assert.noDeprecationsOccurred = function() {
+  this.deepEqual(deprecations, [], 'Expected no deprecations during test.');
+};
+
+QUnit.assert.deprecations = function(callback, expectedDeprecations) {
+  let originalDeprecations = deprecations;
+  deprecations = [];
+
+  callback();
+  this.deepEqual(deprecations, expectedDeprecations, 'Expected deprecations during test.');
+
+  deprecations = originalDeprecations;
+};

--- a/tests/unit/getowner-test.js
+++ b/tests/unit/getowner-test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 const { getOwner } = Ember;
 
 moduleFor('foo:bar', {
@@ -7,7 +8,16 @@ moduleFor('foo:bar', {
     this.register('whatever:lol', Ember.Object.extend({
       isLOL: true
     }));
+  },
+
+  afterEach(assert) {
+    assert.noDeprecationsOccurred();
   }
+});
+
+test('calling getOwner multiple times returns the same object', function(assert) {
+  let subject = this.subject();
+  assert.equal(getOwner(subject), getOwner(subject));
 });
 
 test('it can use getOwner to look things up', function(assert) {
@@ -33,6 +43,33 @@ test('it can use getOwner to register things', function(assert) {
 });
 
 test('it can use getOwner for the private _lookupFactory', function(assert) {
+  let testFn = () => {
+    let subject = this.subject();
+    let owner = getOwner(subject);
+
+    let Baz = Ember.Object.extend();
+    Baz.reopenClass({ isBazFactory: true });
+
+    owner.register('foo:baz', Baz);
+
+    let result = owner._lookupFactory('foo:baz');
+
+    assert.ok(result.isBazFactory, 'was able to register and _lookupFactory');
+  };
+
+  // we only can assert that a deprecation occurs when we are using
+  // our custom `getOwner` polyfill. For Ember 2.3 - 2.11 we simply confirm
+  // the functionality (not the deprecation).
+  if (!hasEmberVersion(2,3) || hasEmberVersion(2,12)) {
+    assert.deprecations(testFn, [
+      'Using "_lookupFactory" is deprecated. Please use container.factoryFor instead.'
+    ]);
+  } else {
+    testFn();
+  }
+});
+
+test('it can use getOwner for factoryFor', function(assert) {
   let subject = this.subject();
   let owner = getOwner(subject);
 
@@ -41,9 +78,11 @@ test('it can use getOwner for the private _lookupFactory', function(assert) {
 
   owner.register('foo:baz', Baz);
 
-  let result = owner._lookupFactory('foo:baz');
+  let result = owner.factoryFor('foo:baz');
 
-  assert.ok(result.isBazFactory, 'was able to register and _lookupFactory');
+  assert.ok(result.class.isBazFactory, 'was able to register and factoryFor');
+  let instance = result.create();
+  assert.ok(instance instanceof Baz, 'factoryFor().create() results in a valid instance');
 });
 
 test('it can use hasRegistration', function(assert) {


### PR DESCRIPTION
* deprecate using `_lookupFactory`
* add ember-factory-for-polyfill
* expose `factoryFor` implementation to our "owner" object
* ensure multiple calls to `getOwner(foo)` return the same instance
* move away from relying on RAISE_ON_DEPRECATION, in favor of simple
  purpose built assertion utils.
* update to latest ember-cli-qunit (to prevent ember-test-helpers
  from triggering a deprecation internally)
* update _lookupFactory test to only confirm deprecation when appropriate